### PR TITLE
Explore New Project Basics

### DIFF
--- a/paste-image.tmux
+++ b/paste-image.tmux
@@ -13,7 +13,9 @@ get_tmux_option() {
 }
 
 # Get the directory of the current script to reliably find our `paster.sh`
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Use readlink to resolve the absolute path, works with run-shell
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]:-$0}")"
+CURRENT_DIR="$(dirname "$SCRIPT_PATH")"
 PASTER_SCRIPT="$CURRENT_DIR/scripts/paster.sh"
 
 # --- User Configurable Options ---


### PR DESCRIPTION
Use readlink to get absolute path instead of BASH_SOURCE with pwd. This fixes the issue where CURRENT_DIR resolves incorrectly when the script is loaded via 'run-shell' in .tmux.conf, causing it to look for paster.sh in ~/scripts/ instead of the plugin directory.

Fixes auto-loading when tmux starts with the plugin configured in .tmux.conf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)