### PR TITLE
feat: add macOS support with pngpaste

### DIFF
--- a/paste-image.tmux
+++ b/paste-image.tmux
@@ -14,7 +14,19 @@ get_tmux_option() {
 
 # Get the directory of the current script to reliably find our `paster.sh`
 # Use readlink to resolve the absolute path, works with run-shell
-SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]:-$0}")"
+# macOS compatible: use greadlink if available, otherwise fall back
+_resolve_path() {
+    if command -v greadlink &> /dev/null; then
+        greadlink -f "$1"
+    elif readlink -f /tmp &> /dev/null 2>&1; then
+        readlink -f "$1"
+    else
+        # macOS fallback: resolve manually
+        local dir="$(cd "$(dirname "$1")" && pwd)"
+        echo "$dir/$(basename "$1")"
+    fi
+}
+SCRIPT_PATH="$(_resolve_path "${BASH_SOURCE[0]:-$0}")"
 CURRENT_DIR="$(dirname "$SCRIPT_PATH")"
 PASTER_SCRIPT="$CURRENT_DIR/scripts/paster.sh"
 

--- a/scripts/paster.sh
+++ b/scripts/paster.sh
@@ -13,15 +13,24 @@ if [ -z "$1" ]; then
 fi
 
 # The directory where screenshots will be saved.
-SCREENSHOT_DIR="$1"
+# Expand ~ and $HOME properly (handles tilde from tmux config)
+SCREENSHOT_DIR="${1/#\~/$HOME}"
+SCREENSHOT_DIR="${SCREENSHOT_DIR/#\$HOME/$HOME}"
 mkdir -p "$SCREENSHOT_DIR"
 
 # --- Dependency Check ---
 
-# Check for xclip (X11) or wl-paste (Wayland).
-if ! command -v xclip &> /dev/null && ! command -v wl-paste &> /dev/null; then
-    tmux display-message "[tmux-paste-image] Error: Please install 'xclip' or 'wl-paste'."
-    exit 1
+# Check for pngpaste (macOS), xclip (X11), or wl-paste (Wayland).
+if [[ "$(uname)" == "Darwin" ]]; then
+    if ! command -v pngpaste &> /dev/null; then
+        tmux display-message "[tmux-paste-image] Error: Please install 'pngpaste' (brew install pngpaste)."
+        exit 1
+    fi
+else
+    if ! command -v xclip &> /dev/null && ! command -v wl-paste &> /dev/null; then
+        tmux display-message "[tmux-paste-image] Error: Please install 'xclip' or 'wl-paste'."
+        exit 1
+    fi
 fi
 
 # --- Main Logic ---
@@ -30,8 +39,10 @@ fi
 FILENAME="image_$(date +%Y-%m-%d_%H-%M-%S).png"
 FILE_PATH="$SCREENSHOT_DIR/$FILENAME"
 
-# Save the clipboard content to the file, checking for Wayland vs. X11.
-if [ -n "$WAYLAND_DISPLAY" ]; then
+# Save the clipboard content to the file, checking platform.
+if [[ "$(uname)" == "Darwin" ]]; then
+    pngpaste "$FILE_PATH"
+elif [ -n "$WAYLAND_DISPLAY" ]; then
     wl-paste --type image/png > "$FILE_PATH"
 else
     xclip -selection clipboard -t image/png -o > "$FILE_PATH"


### PR DESCRIPTION
## Summary

This PR adds macOS support to tmux-paste-image, which previously only worked on Linux (X11/Wayland).

## Changes

- **macOS clipboard support**: Uses [`pngpaste`](https://github.com/jcsalterego/pngpaste) on macOS instead of `xclip`/`wl-paste`. Installable via `brew install pngpaste`.
- **Fix tilde (`~`) expansion**: The save path from tmux config (e.g. `@paste-image-path ~/Pictures/clipboard-pastes`) was passed as a literal `~` string. Now properly expands `~` and `$HOME` in the paster script.
- **macOS-compatible path resolution**: Replaces `readlink -f` (not available on macOS by default) with a cross-platform `_resolve_path()` function that tries `greadlink`, then `readlink -f`, then falls back to manual resolution.

## Testing

Tested on macOS 15 with:
- `pngpaste` installed via Homebrew
- Images copied to clipboard via `Cmd+Shift+4`
- `prefix + P` correctly saves image and pastes path into pane
- Claude Code detection and `/image` command integration works

## Dependencies (macOS only)

```
brew install pngpaste
```